### PR TITLE
Fix critical import issues blocking tests

### DIFF
--- a/tests/integration/test_seed_integration.py
+++ b/tests/integration/test_seed_integration.py
@@ -23,7 +23,7 @@ try:
 except ImportError:
     HAS_TORCH = False
 
-from src.hydro_forecasting.experiment_utils.seed_manager import SeedManager
+from hydro_forecasting.experiment_utils.seed_manager import SeedManager
 
 
 class TestSeedManagerIntegration:

--- a/tests/unit/test_seed_manager.py
+++ b/tests/unit/test_seed_manager.py
@@ -31,7 +31,7 @@ try:
 except ImportError:
     HAS_PYTORCH_LIGHTNING = False
 
-from src.hydro_forecasting.experiment_utils.seed_manager import (
+from hydro_forecasting.experiment_utils.seed_manager import (
     SeedManager,
     get_global_seed_manager,
     init_global_seed_manager,
@@ -211,7 +211,7 @@ class TestSeedManager:
         """Test setting global seeds when master seed is available."""
         with patch("random.seed") as mock_random_seed:
             # Mock PyTorch Lightning to test fallback behavior
-            with patch("src.hydro_forecasting.experiment_utils.seed_manager.HAS_PYTORCH_LIGHTNING", False):
+            with patch("hydro_forecasting.experiment_utils.seed_manager.HAS_PYTORCH_LIGHTNING", False):
                 seed_manager.set_global_seeds()
                 mock_random_seed.assert_called_once_with(test_seed)
 
@@ -228,7 +228,7 @@ class TestSeedManager:
         """Test setting global seeds includes NumPy."""
         with patch("numpy.random.seed") as mock_numpy_seed:
             # Mock PyTorch Lightning to test fallback behavior
-            with patch("src.hydro_forecasting.experiment_utils.seed_manager.HAS_PYTORCH_LIGHTNING", False):
+            with patch("hydro_forecasting.experiment_utils.seed_manager.HAS_PYTORCH_LIGHTNING", False):
                 seed_manager.set_global_seeds()
                 mock_numpy_seed.assert_called_once_with(test_seed)
 
@@ -237,7 +237,7 @@ class TestSeedManager:
         """Test setting global seeds includes PyTorch."""
         with patch("torch.manual_seed") as mock_torch_seed:
             # Mock PyTorch Lightning to test fallback behavior
-            with patch("src.hydro_forecasting.experiment_utils.seed_manager.HAS_PYTORCH_LIGHTNING", False):
+            with patch("hydro_forecasting.experiment_utils.seed_manager.HAS_PYTORCH_LIGHTNING", False):
                 seed_manager.set_global_seeds()
                 mock_torch_seed.assert_called_once_with(test_seed)
 


### PR DESCRIPTION
## Summary
- Fixed ModuleNotFoundError preventing tests from running
- Updated import paths from `src.hydro_forecasting` to `hydro_forecasting`
- Tests now execute successfully

## Changes
- `tests/integration/test_seed_integration.py`: Updated import on line 26
- `tests/unit/test_seed_manager.py`: Updated imports on lines 34-39 and patch paths on lines 214, 231, 240

## Test Results
After this fix:
- ✅ 245 tests collected
- ✅ 243 tests passed
- ❌ 2 tests failed (unrelated to import issues)

The critical import blocker has been resolved.

Fixes #1

🤖 Generated with [Claude Code](https://claude.ai/code)